### PR TITLE
feat: add expand and refresh controls

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,6 +18,18 @@
   "windLineColor": "#AA00F2",
   "windGustLineColor": "#E6D300",
   "precipitationBarColor": "#006EDB",
-  "maxPrecipitationColor": "#00B8F1",
-  "refreshIconColor": "#333333"
-}
+    "maxPrecipitationColor": "#00B8F1",
+    "refreshButtonBackgroundColor": "#FFFFFFB3",
+    "refreshButtonIconColor": "#333333",
+    "expandButtonBackgroundColor": "#333333",
+    "expandButtonIconColor": "#FFFFFF",
+    "expandButtonBorderRadius": 4,
+    "popupBackgroundColor": "#FFFFFF",
+    "popupPadding": 8,
+    "popupBorderRadius": 4,
+    "popupBoxShadowOffsetX": 0,
+    "popupBoxShadowOffsetY": 4,
+    "popupBoxShadowBlur": 10,
+    "popupBoxShadowSpread": 0,
+    "popupBoxShadowColor": "#00000066"
+  }

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -29,8 +29,22 @@ export interface Config {
   precipitationBarColor: string
   maxPrecipitationColor: string
 
-  // UI
-  refreshIconColor: string
+  // UI buttons
+  refreshButtonBackgroundColor: string
+  refreshButtonIconColor: string
+  expandButtonBackgroundColor: string
+  expandButtonIconColor: string
+  expandButtonBorderRadius: number
+
+  // Popup
+  popupBackgroundColor: string
+  popupPadding: number
+  popupBorderRadius: number
+  popupBoxShadowOffsetX: number
+  popupBoxShadowOffsetY: number
+  popupBoxShadowBlur: number
+  popupBoxShadowSpread: number
+  popupBoxShadowColor: string
 }
 
 export type IMConfig = ImmutableObject<Config>

--- a/src/runtime/widget.tsx
+++ b/src/runtime/widget.tsx
@@ -8,6 +8,7 @@ interface State {
   isLoading: boolean
   error: string | null
   rawSvg: string | null
+  expanded: boolean
 }
 
 export default class Widget extends React.PureComponent<AllWidgetProps<IMConfig>, State> {
@@ -15,7 +16,7 @@ export default class Widget extends React.PureComponent<AllWidgetProps<IMConfig>
 
   constructor (props) {
     super(props)
-    this.state = { svgHtml: null, isLoading: false, error: null, rawSvg: null }
+    this.state = { svgHtml: null, isLoading: false, error: null, rawSvg: null, expanded: false }
   }
 
   componentDidMount(): void {
@@ -62,8 +63,12 @@ export default class Widget extends React.PureComponent<AllWidgetProps<IMConfig>
     }
   }
 
-  fetchSvgFromUrl = (url: string): void => {
-    this.setState({ isLoading: true, error: null })
+  toggleExpand = (): void => {
+    this.setState({ expanded: !this.state.expanded })
+  }
+
+  fetchSvgFromUrl = (url: string, attempt = 1): void => {
+    if (attempt === 1) this.setState({ isLoading: true, error: null })
     const proxyUrl = 'https://api.allorigins.win/raw?url='
     const finalUrl = `${proxyUrl}${encodeURIComponent(url)}`
 
@@ -92,6 +97,10 @@ export default class Widget extends React.PureComponent<AllWidgetProps<IMConfig>
         }
       })
       .catch(err => {
+        if (attempt < 3) {
+          setTimeout(() => this.fetchSvgFromUrl(url, attempt + 1), 1000 * attempt)
+          return
+        }
         console.error('Failed to fetch SVG:', err)
         this.setState({ error: 'Failed to load graph. Using fallback if available.', isLoading: false })
 
@@ -141,13 +150,16 @@ export default class Widget extends React.PureComponent<AllWidgetProps<IMConfig>
   buildScopedCss = (config: IMConfig, scope: string) => `
     .${scope} { background-color: ${config.overallBackground}; position: relative; }
 
-    .${scope} .refresh-button {
-      position: absolute; top: 8px; right: 8px;
-      cursor: pointer; background: rgba(255,255,255,0.7);
-      border-radius: 50%; padding: 2px; z-index: 10; line-height: 0; border: none;
-      color: ${config.refreshIconColor};
+    .${scope} .button-container { position: absolute; top: 8px; right: 8px; display: flex; gap: 8px; z-index: 10; }
+    .${scope} .action-button {
+      cursor: pointer; border: none; line-height: 0;
+      display: flex; align-items: center; justify-content: center;
+      height: 32px; width: 32px; border-radius: ${config.expandButtonBorderRadius}px;
     }
+    .${scope} .refresh-button { background: ${config.refreshButtonBackgroundColor}; color: ${config.refreshButtonIconColor}; }
     .${scope} .refresh-button svg path { stroke: currentColor !important; fill: none !important; }
+    .${scope} .refresh-button.large { width: 40px; height: 40px; }
+    .${scope} .expand-button { background: ${config.expandButtonBackgroundColor}; color: ${config.expandButtonIconColor}; font-size: 16px; }
 
     .${scope} .svg-image-container svg { width:100%; height:100%; display:block; background-color:${config.overallBackground} !important; }
 
@@ -234,35 +246,101 @@ export default class Widget extends React.PureComponent<AllWidgetProps<IMConfig>
 
   render(): React.ReactElement {
     const { config, id } = this.props
-    const { isLoading, error, svgHtml } = this.state
+    const { isLoading, error, svgHtml, expanded } = this.state
     const scopeClass = `yrw-${id}`
 
-    if (isLoading) return <Loading />
-    if (error) return <div style={{ padding: '10px', textAlign: 'center', color: 'red' }}>{error}</div>
+    const content = isLoading
+      ? <Loading />
+      : error
+        ? <div style={{ padding: '10px', textAlign: 'center', color: 'red' }}>
+            {error}
+            {config.sourceUrl && (
+              <div style={{ marginTop: 10 }}>
+                <button
+                  className="action-button refresh-button large"
+                  onClick={() => this.fetchSvgFromUrl(config.sourceUrl)}
+                  title="Refresh graph"
+                  aria-label="Refresh graph"
+                >
+                  <svg viewBox="0 0 24 24" width="14" height="14" role="img" aria-hidden="true">
+                    <path strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                      d="M21 12a9 9 0 1 1-3.4-7L21 8m0-4v4h-4" />
+                  </svg>
+                </button>
+              </div>
+            )}
+          </div>
+        : (svgHtml
+            ? <div className="svg-image-container" dangerouslySetInnerHTML={{ __html: svgHtml }} />
+            : <div style={{ padding: 10, textAlign: 'center' }}>
+                Please configure a Source URL or provide Fallback SVG Code.
+              </div>)
 
     return (
       <div className={scopeClass} css={this.getStyle(config)}>
         <style dangerouslySetInnerHTML={{ __html: this.buildScopedCss(config, scopeClass) }} />
 
-        {this.props.config.sourceUrl && (
-          <button
-            className="refresh-button"
-            onClick={() => this.fetchSvgFromUrl(config.sourceUrl)}
-            title="Refresh graph"
-            aria-label="Refresh graph"
-          >
-            <svg viewBox="0 0 24 24" width="14" height="14" role="img" aria-hidden="true">
-              <path strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-                d="M21 12a9 9 0 1 1-3.4-7L21 8m0-4v4h-4" />
-            </svg>
-          </button>
+        {this.props.config.sourceUrl && !expanded && (
+          <div className="button-container">
+            <button
+              className="action-button refresh-button"
+              onClick={() => this.fetchSvgFromUrl(config.sourceUrl)}
+              title="Refresh graph"
+              aria-label="Refresh graph"
+            >
+              <svg viewBox="0 0 24 24" width="14" height="14" role="img" aria-hidden="true">
+                <path strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                  d="M21 12a9 9 0 1 1-3.4-7L21 8m0-4v4h-4" />
+              </svg>
+            </button>
+            <button
+              className="action-button expand-button"
+              onClick={this.toggleExpand}
+              title="Expand graph"
+              aria-label="Expand graph"
+            >⛶</button>
+          </div>
         )}
 
-        {svgHtml
-          ? <div className="svg-image-container" dangerouslySetInnerHTML={{ __html: svgHtml }} />
-          : <div style={{ padding: 10, textAlign: 'center' }}>
-              Please configure a Source URL or provide Fallback SVG Code.
-            </div>}
+        {!expanded && content}
+
+        {expanded && (
+          <div
+            style={{
+              position: 'fixed',
+              top: '15%',
+              left: '15%',
+              width: '70%',
+              height: '70%',
+              background: config.popupBackgroundColor,
+              zIndex: 1000,
+              padding: `${config.popupPadding}px`,
+              borderRadius: `${config.popupBorderRadius}px`,
+              boxShadow: `${config.popupBoxShadowOffsetX}px ${config.popupBoxShadowOffsetY}px ${config.popupBoxShadowBlur}px ${config.popupBoxShadowSpread}px ${config.popupBoxShadowColor}`
+            }}
+          >
+            <div className="button-container">
+              <button
+                className="action-button refresh-button"
+                onClick={() => this.fetchSvgFromUrl(config.sourceUrl)}
+                title="Refresh graph"
+                aria-label="Refresh graph"
+              >
+                <svg viewBox="0 0 24 24" width="14" height="14" role="img" aria-hidden="true">
+                  <path strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                    d="M21 12a9 9 0 1 1-3.4-7L21 8m0-4v4h-4" />
+                </svg>
+              </button>
+              <button
+                className="action-button expand-button"
+                onClick={this.toggleExpand}
+                title="Close graph"
+                aria-label="Close graph"
+              >×</button>
+            </div>
+            {content}
+          </div>
+        )}
       </div>
     )
   }

--- a/src/setting/setting.tsx
+++ b/src/setting/setting.tsx
@@ -97,8 +97,11 @@ export default class Setting extends React.PureComponent<AllWidgetSettingProps<I
           <SettingRow label={intl.formatMessage({ id: 'overallBackground', defaultMessage: defaultMessages.overallBackground })}>
             <ThemeColorPicker value={config.overallBackground} onChange={(color) => { this.onConfigChange('overallBackground', color) }} />
           </SettingRow>
-          <SettingRow label="Refresh Icon">
-            <ThemeColorPicker value={config.refreshIconColor} onChange={(color) => { this.onConfigChange('refreshIconColor', color) }} />
+          <SettingRow label={intl.formatMessage({ id: 'refreshButtonBackground', defaultMessage: defaultMessages.refreshButtonBackground })}>
+            <ThemeColorPicker value={config.refreshButtonBackgroundColor} onChange={(color) => { this.onConfigChange('refreshButtonBackgroundColor', color) }} />
+          </SettingRow>
+          <SettingRow label={intl.formatMessage({ id: 'refreshButtonIcon', defaultMessage: defaultMessages.refreshButtonIcon })}>
+            <ThemeColorPicker value={config.refreshButtonIconColor} onChange={(color) => { this.onConfigChange('refreshButtonIconColor', color) }} />
           </SettingRow>
           <div style={horizontalRowStyle}>
             <span style={labelTextStyle}>{intl.formatMessage({ id: 'padding', defaultMessage: defaultMessages.padding })}</span>
@@ -167,6 +170,49 @@ export default class Setting extends React.PureComponent<AllWidgetSettingProps<I
           </SettingRow>
           <SettingRow label={intl.formatMessage({ id: 'maxPrecipitationColor', defaultMessage: defaultMessages.maxPrecipitationColor })}>
             <ThemeColorPicker value={config.maxPrecipitationColor} onChange={(color) => { this.onConfigChange('maxPrecipitationColor', color) }} />
+          </SettingRow>
+        </SettingSection>
+
+        <SettingSection title={intl.formatMessage({ id: 'expandPopupStyling', defaultMessage: defaultMessages.expandPopupStyling })}>
+          <SettingRow label={intl.formatMessage({ id: 'expandButtonBackground', defaultMessage: defaultMessages.expandButtonBackground })}>
+            <ThemeColorPicker value={config.expandButtonBackgroundColor} onChange={(color) => { this.onConfigChange('expandButtonBackgroundColor', color) }} />
+          </SettingRow>
+          <SettingRow label={intl.formatMessage({ id: 'expandButtonIcon', defaultMessage: defaultMessages.expandButtonIcon })}>
+            <ThemeColorPicker value={config.expandButtonIconColor} onChange={(color) => { this.onConfigChange('expandButtonIconColor', color) }} />
+          </SettingRow>
+          <div style={horizontalRowStyle}>
+            <span style={labelTextStyle}>{intl.formatMessage({ id: 'expandButtonBorderRadius', defaultMessage: defaultMessages.expandButtonBorderRadius })}</span>
+            <NumericInput style={narrowNumericBoxStyle} value={config.expandButtonBorderRadius} onAcceptValue={(value) => { this.onConfigChange('expandButtonBorderRadius', value) }} min={0} step={1} showHandlers={false} size="sm" suffix="px" />
+          </div>
+          <SettingRow label={intl.formatMessage({ id: 'popupBackground', defaultMessage: defaultMessages.popupBackground })}>
+            <ThemeColorPicker value={config.popupBackgroundColor} onChange={(color) => { this.onConfigChange('popupBackgroundColor', color) }} />
+          </SettingRow>
+          <div style={horizontalRowStyle}>
+            <span style={labelTextStyle}>{intl.formatMessage({ id: 'popupPadding', defaultMessage: defaultMessages.popupPadding })}</span>
+            <NumericInput style={narrowNumericBoxStyle} value={config.popupPadding} onAcceptValue={(value) => { this.onConfigChange('popupPadding', value) }} min={0} step={1} showHandlers={false} size="sm" suffix="px" />
+          </div>
+          <div style={horizontalRowStyle}>
+            <span style={labelTextStyle}>{intl.formatMessage({ id: 'popupBorderRadius', defaultMessage: defaultMessages.popupBorderRadius })}</span>
+            <NumericInput style={narrowNumericBoxStyle} value={config.popupBorderRadius} onAcceptValue={(value) => { this.onConfigChange('popupBorderRadius', value) }} min={0} step={1} showHandlers={false} size="sm" suffix="px" />
+          </div>
+          <div style={horizontalRowStyle}>
+            <span style={labelTextStyle}>{intl.formatMessage({ id: 'popupBoxShadowOffsetX', defaultMessage: defaultMessages.popupBoxShadowOffsetX })}</span>
+            <NumericInput style={narrowNumericBoxStyle} value={config.popupBoxShadowOffsetX} onAcceptValue={(value) => { this.onConfigChange('popupBoxShadowOffsetX', value) }} step={1} showHandlers={false} size="sm" suffix="px" />
+          </div>
+          <div style={horizontalRowStyle}>
+            <span style={labelTextStyle}>{intl.formatMessage({ id: 'popupBoxShadowOffsetY', defaultMessage: defaultMessages.popupBoxShadowOffsetY })}</span>
+            <NumericInput style={narrowNumericBoxStyle} value={config.popupBoxShadowOffsetY} onAcceptValue={(value) => { this.onConfigChange('popupBoxShadowOffsetY', value) }} step={1} showHandlers={false} size="sm" suffix="px" />
+          </div>
+          <div style={horizontalRowStyle}>
+            <span style={labelTextStyle}>{intl.formatMessage({ id: 'popupBoxShadowBlur', defaultMessage: defaultMessages.popupBoxShadowBlur })}</span>
+            <NumericInput style={narrowNumericBoxStyle} value={config.popupBoxShadowBlur} onAcceptValue={(value) => { this.onConfigChange('popupBoxShadowBlur', value) }} min={0} step={1} showHandlers={false} size="sm" suffix="px" />
+          </div>
+          <div style={horizontalRowStyle}>
+            <span style={labelTextStyle}>{intl.formatMessage({ id: 'popupBoxShadowSpread', defaultMessage: defaultMessages.popupBoxShadowSpread })}</span>
+            <NumericInput style={narrowNumericBoxStyle} value={config.popupBoxShadowSpread} onAcceptValue={(value) => { this.onConfigChange('popupBoxShadowSpread', value) }} step={1} showHandlers={false} size="sm" suffix="px" />
+          </div>
+          <SettingRow label={intl.formatMessage({ id: 'popupBoxShadowColor', defaultMessage: defaultMessages.popupBoxShadowColor })}>
+            <ThemeColorPicker value={config.popupBoxShadowColor} onChange={(color) => { this.onConfigChange('popupBoxShadowColor', color) }} />
           </SettingRow>
         </SettingSection>
       </div>

--- a/src/setting/translations/default.ts
+++ b/src/setting/translations/default.ts
@@ -25,5 +25,18 @@ export default {
     windGustLineColor: 'Wind Gust',
     precipitationBarColor: 'Precipitation',
     maxPrecipitationColor: 'Max Precipitation',
-    refreshIconColor: 'Refresh Icon'
+    refreshButtonBackground: 'Refresh Button Background',
+    refreshButtonIcon: 'Refresh Button Icon',
+    expandPopupStyling: 'Expand & Popup Styling',
+    expandButtonBackground: 'Expand Button Background',
+    expandButtonIcon: 'Expand Button Icon',
+    expandButtonBorderRadius: 'Action Button Border Radius',
+    popupBackground: 'Popup Background',
+    popupPadding: 'Popup Padding',
+    popupBorderRadius: 'Popup Border Radius',
+    popupBoxShadowOffsetX: 'Popup Shadow Offset X',
+    popupBoxShadowOffsetY: 'Popup Shadow Offset Y',
+    popupBoxShadowBlur: 'Popup Shadow Blur',
+    popupBoxShadowSpread: 'Popup Shadow Spread',
+    popupBoxShadowColor: 'Popup Shadow Color'
 }


### PR DESCRIPTION
## Summary
- add configurable refresh button styling and expand popup
- implement retry logic and inline refresh when API fails
- expose expand/popup options in settings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc17977de08330977f9785c40b62cc